### PR TITLE
Add basic pytest tests

### DIFF
--- a/tests/test_model_finder.py
+++ b/tests/test_model_finder.py
@@ -1,0 +1,32 @@
+import os
+from utils.model_finder import find_model_executable
+
+
+def test_find_executable_in_subfolder(tmp_path):
+    base_dir = tmp_path / "models"
+    sub = base_dir / "sub1"
+    sub.mkdir(parents=True)
+    exe = sub / "waifu2x.exe"
+    exe.write_text("")
+
+    result = find_model_executable(str(base_dir), "waifu2x", exe_name="waifu2x.exe")
+    assert result == str(exe)
+
+
+def test_find_executable_in_subsubfolder(tmp_path):
+    base_dir = tmp_path / "models"
+    sub = base_dir / "sub1" / "sub2"
+    sub.mkdir(parents=True)
+    exe = sub / "model.exe"
+    exe.write_text("")
+
+    result = find_model_executable(str(base_dir), "model", exe_name="model.exe")
+    assert result == str(exe)
+
+
+def test_executable_not_found(tmp_path):
+    base_dir = tmp_path / "models"
+    base_dir.mkdir()
+
+    result = find_model_executable(str(base_dir), "missing", exe_name="missing.exe")
+    assert result is None

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -1,0 +1,63 @@
+import os
+from pathlib import Path
+import builtins
+
+import core.operator as operator
+
+
+def dummy_logger():
+    class Dummy:
+        def info(self, *args, **kwargs):
+            pass
+        def error(self, *args, **kwargs):
+            pass
+        def warning(self, *args, **kwargs):
+            pass
+        def debug(self, *args, **kwargs):
+            pass
+    return Dummy()
+
+
+def test_process_request_returns_existing_output(tmp_path, monkeypatch):
+    # Prepare input image
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    img = input_dir / "test.png"
+    img.write_text("data")
+
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+
+    temp_dir = tmp_path / "temp"
+
+    # Patch utilities used in process_request
+    def fake_create_temp_folder(*args, **kwargs):
+        temp_dir.mkdir(exist_ok=True)
+        return str(temp_dir)
+    monkeypatch.setattr(operator, "create_temp_folder", fake_create_temp_folder)
+
+    def fake_process_image(frame_dir, output_path, logger=None):
+        Path(output_path).write_text("processed")
+    monkeypatch.setattr(operator, "process_image", fake_process_image)
+
+    monkeypatch.setattr(operator, "run_upscaling", lambda *a, **k: {"success": True})
+    monkeypatch.setattr(operator, "run_interpolation", lambda *a, **k: {"success": True})
+    monkeypatch.setattr(operator, "get_logger", lambda *a, **k: dummy_logger())
+
+    request = {
+        "input_path": str(img),
+        "input_format": "png",
+        "task": "upscaling",
+        "upscaling": {"enabled": False},
+        "interpolation": {"enabled": False},
+        "output_path": str(output_dir),
+        "log_path": str(tmp_path / "log.txt"),
+    }
+
+    result = operator.process_request(request)
+
+    assert result["status"] == "success"
+    assert Path(result["output_path"]).exists()
+    files = list(output_dir.iterdir())
+    assert len(files) == 1
+    assert files[0] == Path(result["output_path"])


### PR DESCRIPTION
## Summary
- add new tests directory with pytest
- cover `utils.model_finder.find_model_executable`
- test `core.operator.process_request` output path for images

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68401a4f6f308333a9345b73a7a99d74