### PR TITLE
Fix startup instructions and batch script

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 
 1. Download/extract Fusion2X.
 2. Double-click `run_fusion2x.bat` (Windows) or run `bash run_fusion2x.sh` (Mac/Linux).
-   - The first run may take a few minutes to create the venv and install packages.
+   - These scripts set up a virtual environment and start the GUI via `gui.py`.
+   - The first run may take a few minutes while dependencies and models are downloaded.
    - All dependencies, models, and FFmpeg will be installed automatically in the `.venv` and `models/` folders.
+   - You can also run `python gui.py` directly if you manage your own environment.
 3. The Fusion2X GUI will launch. All logs are saved in `logs/`.
 
 ## To update Fusion2X

--- a/run_fusion2x.bat
+++ b/run_fusion2x.bat
@@ -15,7 +15,7 @@ if not exist logs (
 )
 
 REM 4. Run the Python entrypoint
-python run_fusion2x.py
+python gui.py
 
 REM 5. Pause so you can read any errors
 pause

--- a/run_fusion2x.sh
+++ b/run_fusion2x.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -e
+
+# 1. Create or activate virtualenv
+if [ ! -d ".venv" ]; then
+  python3 -m venv .venv
+fi
+source .venv/bin/activate
+
+# 2. Install/update dependencies
+pip install --upgrade pip
+pip install -r requirements.txt
+
+# 3. Ensure logs folder exists
+mkdir -p logs
+
+# 4. Run the Python entrypoint
+python gui.py
+


### PR DESCRIPTION
## Summary
- point README to the new entrypoint script
- run the GUI from `gui.py` in `run_fusion2x.bat`
- add a Unix `run_fusion2x.sh` script

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68401a4a362483338e1c661066f9d5ed