### PR TITLE
Fix logger module name

### DIFF
--- a/core/operator.py
+++ b/core/operator.py
@@ -44,7 +44,7 @@ def get_run_log_path():
     return os.path.join("logs", f"fusion2x_{dt}_{rid}.log")
 
 log_path = get_run_log_path()
-logger = get_logger(log_path, module_name="Receiver")
+logger = get_logger(log_path, module_name="Operator")
 
 
 def find_model_executable(model_root, model_name, exe_name=None):


### PR DESCRIPTION
## Summary
- fix incorrect logger name in `core/operator.py`

## Testing
- `python -m py_compile core/operator.py`


------
https://chatgpt.com/codex/tasks/task_e_68401a478d4083338693d8dae2546597