### PR TITLE
Fix CLI args for waifu2x and other models

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -303,7 +303,6 @@ class Fusion2XGUI(QWidget):
                 "params": {
                     "scale": self.upscale_scale.value(),
                     "noise_level": self.upscale_noise.value(),
-                    "mode": "noise_scale",
                     "output_format": self.upscale_output_format.currentText(),
                     "gpu_id": self.upscale_gpu.value(),
                     "threads": self.upscale_threads.value()

--- a/handlers/models/realcugan_ncnn_vulkan.py
+++ b/handlers/models/realcugan_ncnn_vulkan.py
@@ -62,7 +62,7 @@ def run_realcugan_ncnn_vulkan(frame_dir, params, logger):
         "-j", str(threads)
     ]
     if tile_size:
-        cmd.extend(["-T", str(tile_size)])
+        cmd.extend(["-t", str(tile_size)])
 
     logger.info(f"[realcugan-ncnn-vulkan] Running: {' '.join(str(x) for x in cmd)}")
     subprocess.run(cmd, check=True)

--- a/handlers/models/realesrgan_ncnn_vulkan.py
+++ b/handlers/models/realesrgan_ncnn_vulkan.py
@@ -60,7 +60,7 @@ def run_realesrgan_ncnn_vulkan(frame_dir, params, logger):
         "-j", str(threads)
     ]
     if tile_size:
-        cmd.extend(["-T", str(tile_size)])
+        cmd.extend(["-t", str(tile_size)])
 
     logger.info(f"[realesrgan-ncnn-vulkan] Running: {' '.join(str(x) for x in cmd)}")
     subprocess.run(cmd, check=True)

--- a/handlers/models/realsr_ncnn_vulkan.py
+++ b/handlers/models/realsr_ncnn_vulkan.py
@@ -59,7 +59,7 @@ def run_realsr_ncnn_vulkan(frame_dir, params, logger):
         "-j", str(threads)
     ]
     if tile_size:
-        cmd.extend(["-T", str(tile_size)])
+        cmd.extend(["-t", str(tile_size)])
 
     logger.info(f"[realsr-ncnn-vulkan] Running: {' '.join(str(x) for x in cmd)}")
     subprocess.run(cmd, check=True)

--- a/handlers/models/rife_ncnn_vulkan.py
+++ b/handlers/models/rife_ncnn_vulkan.py
@@ -56,16 +56,23 @@ def run_rife_ncnn_vulkan(frame_dir, params, logger):
 
     cmd = [
         exe_path,
-        "-i", frame_dir,
-        "-o", output_dir,
-        "-x", str(times),
-        "-m", model,
-        "-f", fmt,
-        "-t", str(threads),
-        "-g", str(gpu_id)
+        "-i",
+        frame_dir,
+        "-o",
+        output_dir,
+        "-n",
+        str(times),
+        "-m",
+        model,
+        "-f",
+        fmt,
+        "-j",
+        str(threads),
+        "-g",
+        str(gpu_id),
     ]
     if tta_mode:
-        cmd.append("--tta")
+        cmd.append("-x")
     if uhd_mode:
         cmd.append("--uhd")
 

--- a/handlers/models/srmd_ncnn_vulkan.py
+++ b/handlers/models/srmd_ncnn_vulkan.py
@@ -62,7 +62,7 @@ def run_srmd_ncnn_vulkan(frame_dir, params, logger):
         "-j", str(threads)
     ]
     if tile_size:
-        cmd.extend(["-T", str(tile_size)])
+        cmd.extend(["-t", str(tile_size)])
 
     logger.info(f"[srmd-ncnn-vulkan] Running: {' '.join(str(x) for x in cmd)}")
     subprocess.run(cmd, check=True)

--- a/handlers/models/waifu2x_ncnn_vulkan.py
+++ b/handlers/models/waifu2x_ncnn_vulkan.py
@@ -6,12 +6,12 @@ supported_waifu2x_ncnn_vulkan_params = [
     "waifu2x_exe_path",   # Path to waifu2x-ncnn-vulkan.exe (optional if using default)
     "scale",              # Scale factor (1, 2, 4, etc.)
     "noise_level",        # Denoise level (0, 1, 2, 3)
-    "mode",               # 'noise', 'scale', or 'noise_scale'
     "model_dir",          # Model directory to use (e.g., models-upconv_7_photo, optional)
     "output_format",      # Output format: png, jpg, etc.
     "gpu_id",             # GPU selection (integer, optional)
     "threads",            # Thread count (optional)
     "tile_size",          # Tile size (optional)
+    "tta",                # Enable TTA mode (boolean, optional)
 ]
 
 def find_default_waifu2x_exe():
@@ -43,12 +43,12 @@ def run_waifu2x_ncnn_vulkan(frame_dir, params, logger):
 
     scale = params.get("scale", 2)
     noise_level = params.get("noise_level", 2)
-    mode = params.get("mode", "noise_scale")
     model_dir = params.get("model_dir")  # e.g., "models-upconv_7_photo"
     output_format = params.get("output_format", "png")
     gpu_id = params.get("gpu_id", 0)
     threads = params.get("threads", 2)
     tile_size = params.get("tile_size", 0)  # 0 = auto
+    tta = params.get("tta", False)
 
     # If model_dir is not given, use a default inside the waifu2x folder
     if not model_dir:
@@ -59,18 +59,27 @@ def run_waifu2x_ncnn_vulkan(frame_dir, params, logger):
 
     cmd = [
         exe_path,
-        "-i", frame_dir,
-        "-o", output_dir,
-        "-n", str(noise_level),
-        "-s", str(scale),
-        "-m", mode,
-        "-f", output_format,
-        "-t", str(gpu_id),
-        "-j", str(threads),
-        "-x", model_dir
+        "-i",
+        frame_dir,
+        "-o",
+        output_dir,
+        "-n",
+        str(noise_level),
+        "-s",
+        str(scale),
+        "-m",
+        model_dir,
+        "-f",
+        output_format,
+        "-g",
+        str(gpu_id),
+        "-j",
+        str(threads),
     ]
     if tile_size:
-        cmd.extend(["-T", str(tile_size)])
+        cmd += ["-t", str(tile_size)]
+    if tta:
+        cmd.append("-x")
 
     logger.info(f"[waifu2x-ncnn-vulkan] Running: {' '.join(str(x) for x in cmd)}")
     subprocess.run(cmd, check=True)


### PR DESCRIPTION
## Summary
- fix argument names passed to all bundled model executables
- remove unused `mode` param from waifu2x settings in GUI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684052a9e14083339a08d66636755c12