### PR TITLE
Improve subprocess logging

### DIFF
--- a/handlers/interpolation_handler.py
+++ b/handlers/interpolation_handler.py
@@ -1,4 +1,5 @@
 from handlers.models.rife_ncnn_vulkan import run_rife_ncnn_vulkan, supported_rife_ncnn_vulkan_params
+import subprocess
 
 # Central registry: key = model name, value = (runner function, supported_params)
 MODEL_REGISTRY = {
@@ -31,6 +32,9 @@ def run_interpolation(frame_dir, interpolation_params, logger):
         logger.info(f"Running interpolation model: {model_name}")
         model_func(frame_dir=frame_dir, params=params, logger=logger)
         return {"success": True, "message": "Interpolation completed."}
+    except subprocess.CalledProcessError as e:
+        logger.error(f"Interpolation model '{model_name}' failed: {e}")
+        return {"success": False, "message": e.stderr}
     except Exception as e:
         logger.error(f"Interpolation model '{model_name}' failed: {e}")
         return {"success": False, "message": str(e)}

--- a/handlers/models/realcugan_ncnn_vulkan.py
+++ b/handlers/models/realcugan_ncnn_vulkan.py
@@ -65,5 +65,10 @@ def run_realcugan_ncnn_vulkan(frame_dir, params, logger):
         cmd.extend(["-t", str(tile_size)])
 
     logger.info(f"[realcugan-ncnn-vulkan] Running: {' '.join(str(x) for x in cmd)}")
-    subprocess.run(cmd, check=True)
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        logger.error(f"Model process failed with code {result.returncode}")
+        logger.error(result.stdout)
+        logger.error(result.stderr)
+        result.check_returncode()
     logger.info(f"[realcugan-ncnn-vulkan] Finished upscaling.")

--- a/handlers/models/realesrgan_ncnn_vulkan.py
+++ b/handlers/models/realesrgan_ncnn_vulkan.py
@@ -63,5 +63,10 @@ def run_realesrgan_ncnn_vulkan(frame_dir, params, logger):
         cmd.extend(["-t", str(tile_size)])
 
     logger.info(f"[realesrgan-ncnn-vulkan] Running: {' '.join(str(x) for x in cmd)}")
-    subprocess.run(cmd, check=True)
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        logger.error(f"Model process failed with code {result.returncode}")
+        logger.error(result.stdout)
+        logger.error(result.stderr)
+        result.check_returncode()
     logger.info(f"[realesrgan-ncnn-vulkan] Finished upscaling.")

--- a/handlers/models/realsr_ncnn_vulkan.py
+++ b/handlers/models/realsr_ncnn_vulkan.py
@@ -62,5 +62,10 @@ def run_realsr_ncnn_vulkan(frame_dir, params, logger):
         cmd.extend(["-t", str(tile_size)])
 
     logger.info(f"[realsr-ncnn-vulkan] Running: {' '.join(str(x) for x in cmd)}")
-    subprocess.run(cmd, check=True)
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        logger.error(f"Model process failed with code {result.returncode}")
+        logger.error(result.stdout)
+        logger.error(result.stderr)
+        result.check_returncode()
     logger.info(f"[realsr-ncnn-vulkan] Finished upscaling.")

--- a/handlers/models/rife_ncnn_vulkan.py
+++ b/handlers/models/rife_ncnn_vulkan.py
@@ -77,6 +77,11 @@ def run_rife_ncnn_vulkan(frame_dir, params, logger):
         cmd.append("--uhd")
 
     logger.info(f"[rife-ncnn-vulkan] Running: {' '.join(str(x) for x in cmd)}")
-    subprocess.run(cmd, check=True)
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        logger.error(f"Model process failed with code {result.returncode}")
+        logger.error(result.stdout)
+        logger.error(result.stderr)
+        result.check_returncode()
     logger.info(f"[rife-ncnn-vulkan] Finished interpolation.")
 

--- a/handlers/models/srmd_ncnn_vulkan.py
+++ b/handlers/models/srmd_ncnn_vulkan.py
@@ -65,5 +65,10 @@ def run_srmd_ncnn_vulkan(frame_dir, params, logger):
         cmd.extend(["-t", str(tile_size)])
 
     logger.info(f"[srmd-ncnn-vulkan] Running: {' '.join(str(x) for x in cmd)}")
-    subprocess.run(cmd, check=True)
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        logger.error(f"Model process failed with code {result.returncode}")
+        logger.error(result.stdout)
+        logger.error(result.stderr)
+        result.check_returncode()
     logger.info(f"[srmd-ncnn-vulkan] Finished upscaling.")

--- a/handlers/models/waifu2x_ncnn_vulkan.py
+++ b/handlers/models/waifu2x_ncnn_vulkan.py
@@ -82,6 +82,11 @@ def run_waifu2x_ncnn_vulkan(frame_dir, params, logger):
         cmd.append("-x")
 
     logger.info(f"[waifu2x-ncnn-vulkan] Running: {' '.join(str(x) for x in cmd)}")
-    subprocess.run(cmd, check=True)
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        logger.error(f"Model process failed with code {result.returncode}")
+        logger.error(result.stdout)
+        logger.error(result.stderr)
+        result.check_returncode()
     logger.info(f"[waifu2x-ncnn-vulkan] Finished upscaling.")
 

--- a/handlers/upscaling_handler.py
+++ b/handlers/upscaling_handler.py
@@ -3,6 +3,7 @@ from handlers.models.realesrgan_ncnn_vulkan import run_realesrgan_ncnn_vulkan, s
 from handlers.models.realcugan_ncnn_vulkan import run_realcugan_ncnn_vulkan, supported_realcugan_ncnn_vulkan_params
 from handlers.models.realsr_ncnn_vulkan import run_realsr_ncnn_vulkan, supported_realsr_ncnn_vulkan_params
 from handlers.models.srmd_ncnn_vulkan import run_srmd_ncnn_vulkan, supported_srmd_ncnn_vulkan_params
+import subprocess
 
 # Central registry: key = model name, value = (runner function, supported_params)
 MODEL_REGISTRY = {
@@ -38,6 +39,9 @@ def run_upscaling(frame_dir, upscaling_params, logger):
         logger.info(f"Running upscaling model: {model_name}")
         model_func(frame_dir=frame_dir, params=params, logger=logger)
         return {"success": True, "message": "Upscaling completed."}
+    except subprocess.CalledProcessError as e:
+        logger.error(f"Upscaling model '{model_name}' failed: {e}")
+        return {"success": False, "message": e.stderr}
     except Exception as e:
         logger.error(f"Upscaling model '{model_name}' failed: {e}")
         return {"success": False, "message": str(e)}

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,0 +1,49 @@
+import subprocess
+from handlers import upscaling_handler, interpolation_handler
+
+
+def dummy_logger():
+    class Dummy:
+        def info(self, *args, **kwargs):
+            pass
+        def error(self, *args, **kwargs):
+            pass
+        def warning(self, *args, **kwargs):
+            pass
+        def debug(self, *args, **kwargs):
+            pass
+    return Dummy()
+
+
+def test_upscaling_success(monkeypatch):
+    def fake_model(frame_dir, params, logger):
+        pass
+    monkeypatch.setitem(upscaling_handler.MODEL_REGISTRY, "test-model", (fake_model, []))
+    res = upscaling_handler.run_upscaling("frames", {"model_name": "test-model", "params": {}}, dummy_logger())
+    assert res["success"] is True
+
+
+def test_upscaling_called_process_error(monkeypatch):
+    def fake_model(frame_dir, params, logger):
+        raise subprocess.CalledProcessError(returncode=1, cmd="x", stderr="err")
+    monkeypatch.setitem(upscaling_handler.MODEL_REGISTRY, "err-model", (fake_model, []))
+    res = upscaling_handler.run_upscaling("frames", {"model_name": "err-model", "params": {}}, dummy_logger())
+    assert res["success"] is False
+    assert res["message"] == "err"
+
+
+def test_interpolation_success(monkeypatch):
+    def fake_model(frame_dir, params, logger):
+        pass
+    monkeypatch.setitem(interpolation_handler.MODEL_REGISTRY, "test-model", (fake_model, []))
+    res = interpolation_handler.run_interpolation("frames", {"model_name": "test-model", "params": {}}, dummy_logger())
+    assert res["success"] is True
+
+
+def test_interpolation_called_process_error(monkeypatch):
+    def fake_model(frame_dir, params, logger):
+        raise subprocess.CalledProcessError(returncode=1, cmd="x", stderr="bad")
+    monkeypatch.setitem(interpolation_handler.MODEL_REGISTRY, "err-model", (fake_model, []))
+    res = interpolation_handler.run_interpolation("frames", {"model_name": "err-model", "params": {}}, dummy_logger())
+    assert res["success"] is False
+    assert res["message"] == "bad"


### PR DESCRIPTION
## Summary
- log stdout/stderr for model runners when external processes fail
- propagate CalledProcessError stderr messages through upscaling/interpolation handlers
- add unit tests for handlers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68406109ed588333842c1351d15d85a4