### PR TITLE
Add persistent options checkboxes

### DIFF
--- a/core/operator.py
+++ b/core/operator.py
@@ -123,14 +123,15 @@ def process_request(json_request):
             logger.info("Starting video encoding.")
             target_fps = metadata.get("fps", 30)
             target_res = metadata.get("resolution", None)
-            out_video_path = os.path.join(temp_folder, f"{file_base}_fusion2x_{now_str}.mp4")
+            output_ext = "." + json_request.get("output_format", "mp4").lstrip(".")
+            out_video_path = os.path.join(temp_folder, f"{file_base}_fusion2x_{now_str}{output_ext}")
             encode_video(frames_dir, out_video_path, fps=target_fps, resolution=target_res, logger=logger)
             logger.info(f"Video encoding complete: {out_video_path}")
 
             # Move result to output directory
             export_dir = json_request.get("output_path") or file_dir
             os.makedirs(export_dir, exist_ok=True)
-            final_name = f"{file_base}_fusion2x_{now_str}{file_ext}"
+            final_name = f"{file_base}_fusion2x_{now_str}{output_ext}"
             # Move the encoded video to the export directory and capture its new location
             moved_path = move_file(out_video_path, export_dir)
             # Rename to the final desired name
@@ -173,7 +174,8 @@ def process_request(json_request):
             # Move final image to export dir
             export_dir = json_request.get("output_path") or file_dir
             os.makedirs(export_dir, exist_ok=True)
-            final_name = f"{file_base}_fusion2x_{now_str}{file_ext}"
+            output_ext = "." + json_request.get("output_format", file_ext.lstrip(".")).lstrip(".")
+            final_name = f"{file_base}_fusion2x_{now_str}{output_ext}"
             final_path = os.path.join(export_dir, final_name)
             process_image(frames_dir, final_path, logger=logger)
             logger.info(f"Moved processed image to: {final_path}")

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -50,6 +50,7 @@ def test_process_request_returns_existing_output(tmp_path, monkeypatch):
         "task": "upscaling",
         "upscaling": {"enabled": False},
         "interpolation": {"enabled": False},
+        "output_format": "png",
         "output_path": str(output_dir),
         "log_path": str(tmp_path / "log.txt"),
     }
@@ -61,3 +62,46 @@ def test_process_request_returns_existing_output(tmp_path, monkeypatch):
     files = list(output_dir.iterdir())
     assert len(files) == 1
     assert files[0] == Path(result["output_path"])
+
+
+def test_process_request_respects_output_format(tmp_path, monkeypatch):
+    input_dir = tmp_path / "input2"
+    input_dir.mkdir()
+    img = input_dir / "orig.png"
+    img.write_text("data")
+
+    output_dir = tmp_path / "out2"
+    output_dir.mkdir()
+
+    temp_dir = tmp_path / "temp2"
+
+    def fake_create_temp_folder(*args, **kwargs):
+        temp_dir.mkdir(exist_ok=True)
+        return str(temp_dir)
+    monkeypatch.setattr(operator, "create_temp_folder", fake_create_temp_folder)
+
+    def fake_process_image(frame_dir, output_path, logger=None):
+        Path(output_path).write_text("processed")
+    monkeypatch.setattr(operator, "process_image", fake_process_image)
+
+    monkeypatch.setattr(operator, "run_upscaling", lambda *a, **k: {"success": True})
+    monkeypatch.setattr(operator, "run_interpolation", lambda *a, **k: {"success": True})
+    monkeypatch.setattr(operator, "get_logger", lambda *a, **k: dummy_logger())
+
+    request = {
+        "input_path": str(img),
+        "input_format": "png",
+        "output_format": "jpg",
+        "task": "upscaling",
+        "upscaling": {"enabled": False},
+        "interpolation": {"enabled": False},
+        "output_path": str(output_dir),
+        "log_path": str(tmp_path / "log2.txt"),
+    }
+
+    result = operator.process_request(request)
+
+    assert result["status"] == "success"
+    assert Path(result["output_path"]).exists()
+    assert Path(result["output_path"]).suffix == ".jpg"
+    assert Path(result["output_path"]).parent == output_dir


### PR DESCRIPTION
## Summary
- checkable option groups return `QGroupBox` objects
- choose `output_format` according to which group is enabled

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68414cadc6388333a04733248d6f9654