### PR TITLE
Improve validation and logging

### DIFF
--- a/core/operator.py
+++ b/core/operator.py
@@ -10,6 +10,7 @@ from handlers.upscaling_handler import run_upscaling
 from handlers.interpolation_handler import run_interpolation
 from utils.logger import get_logger
 from utils.file_utils import create_temp_folder, safe_rename, move_file
+from utils.logfile_utils import make_log_filename
 
 """
 Fusion2X Operator
@@ -30,14 +31,7 @@ def get_run_log_path():
     if env_path:
         return env_path
 
-    import datetime
-    import random
-    import string
-
-    dt = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-    rid = ''.join(random.choices(string.ascii_lowercase + string.digits, k=6))
-    os.makedirs("logs", exist_ok=True)
-    return os.path.join("logs", f"fusion2x_{dt}_{rid}.log")
+    return make_log_filename()
 
 
 log_path = get_run_log_path()

--- a/gui.py
+++ b/gui.py
@@ -2,9 +2,6 @@ import os
 import sys
 import json
 import subprocess
-import datetime
-import random
-import string
 
 sys.path.insert(
     0,
@@ -27,16 +24,12 @@ from PyQt5.QtWidgets import (  # noqa: E402
 )
 
 from utils.logger import get_logger  # noqa: E402
+from utils.logfile_utils import make_log_filename
 gui_log_path = os.path.join("logs", "gui.log")
 os.makedirs("logs", exist_ok=True)
 logger = get_logger(gui_log_path, module_name="GUI")
 
 
-def make_log_filename():
-    dt = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-    rid = ''.join(random.choices(string.ascii_lowercase + string.digits, k=6))
-    os.makedirs("logs", exist_ok=True)
-    return os.path.join("logs", f"fusion2x_{dt}_{rid}.log")
 
 
 # Model options (update if you add more in handlers)

--- a/install_fusion2x.py
+++ b/install_fusion2x.py
@@ -2,12 +2,22 @@ import sys
 import subprocess
 import shutil
 import platform
+import os
 
 REQUIREMENTS = [
     "tqdm",
-    "jsonschema"
-    # Add more as needed
+    "jsonschema",
 ]
+
+
+def load_requirements():
+    """Return a list of required packages."""
+    req_path = os.path.join(os.path.dirname(__file__), "requirements.txt")
+    if os.path.exists(req_path):
+        with open(req_path, "r", encoding="utf-8") as f:
+            lines = [l.strip() for l in f.readlines()]
+        return [l for l in lines if l and not l.startswith("#")]
+    return REQUIREMENTS
 
 def print_header():
     print("="*50)
@@ -56,7 +66,7 @@ def print_model_binary_instructions():
 def main():
     print_header()
     check_python_version()
-    pip_install(REQUIREMENTS)
+    pip_install(load_requirements())
     check_ffmpeg()
     print_model_binary_instructions()
     print("\n[!] Fusion2X installation complete. You can now run the program.")

--- a/media/video_decoder.py
+++ b/media/video_decoder.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+from utils.process_utils import require_binaries
 
 def extract_frames(video_path, output_dir, output_format="png", logger=None):
     """
@@ -15,6 +16,7 @@ def extract_frames(video_path, output_dir, output_format="png", logger=None):
     Returns:
         dict: Metadata with keys frame_count, resolution, fps.
     """
+    require_binaries(["ffmpeg", "ffprobe"])
     if not os.path.exists(output_dir):
         os.makedirs(output_dir, exist_ok=True)
     # ffmpeg command

--- a/media/video_encoder.py
+++ b/media/video_encoder.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+from utils.process_utils import require_binaries
 
 def encode_video(frame_dir, output_path, fps=30, resolution=None, format="mp4", logger=None):
     """
@@ -13,6 +14,7 @@ def encode_video(frame_dir, output_path, fps=30, resolution=None, format="mp4", 
         format (str): Output video format, default mp4.
         logger: Logger instance.
     """
+    require_binaries(["ffmpeg"])
     input_pattern = os.path.join(frame_dir, "frame_%06d.png")
     cmd = [
         "ffmpeg", "-framerate", str(fps), "-i", input_pattern

--- a/utils/process_utils.py
+++ b/utils/process_utils.py
@@ -1,4 +1,14 @@
 import subprocess
+import shutil
+
+
+def require_binaries(names):
+    """Ensure each binary in names exists in PATH."""
+    for name in names:
+        if shutil.which(name) is None:
+            raise FileNotFoundError(
+                f"Required binary '{name}' not found in PATH."
+            )
 
 
 def run_model_command(cmd, logger):


### PR DESCRIPTION
## Summary
- use standard make_log_filename across modules
- validate requests with `validate_json_request`
- check ffmpeg binaries before using them
- allow installer to read dependencies from `requirements.txt`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684271bce6d4833392f601bb67cf46ad