### PR TITLE
Improve crash guidance and add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+.venv/
+logs/
+*.pyc
+__pycache__

--- a/README.md
+++ b/README.md
@@ -17,3 +17,19 @@
   is missing, then pull the newest code and refresh all Python dependencies in
   the `.venv` environment.
 
+## Troubleshooting
+
+### "The process crashed (0xC0000005)" error
+
+If a model process exits with code `0xC0000005`, it usually means there is a
+problem with the underlying GPU or runtime libraries. To resolve this:
+
+1. **Update GPU drivers** – install the latest drivers for your graphics card
+   from the vendor's website (NVIDIA, AMD or Intel).
+2. **Install the Microsoft Visual C++ Redistributable** – on Windows make sure
+   the [Visual C++ Runtime](https://learn.microsoft.com/cpp/windows/latest-supported-vc-redist)
+   is installed.
+
+After installing the required drivers and runtime components, try running
+Fusion2X again.
+

--- a/utils/process_utils.py
+++ b/utils/process_utils.py
@@ -28,7 +28,9 @@ def run_model_command(cmd, logger):
     if result.returncode in (3221225477, -1073741819):
         hint = (
             "The process crashed (0xC0000005). This often indicates missing or "
-            "incompatible GPU drivers or Visual C++ runtime components."
+            "incompatible GPU drivers or Visual C++ runtime components. "
+            "Please ensure your graphics drivers are up to date and install "
+            "the Microsoft Visual C++ Redistributable."
         )
     else:
         hint = f"Model process returned exit code {result.returncode}."


### PR DESCRIPTION
## Summary
- document how to fix the `0xC0000005` crash in the README
- expand runtime crash hint with driver/runtime instructions
- add `.gitignore` for virtualenv, logs and `__pycache__`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68427faf917083339a8f350d01b8c7da