### PR TITLE
Add CLI handling to receiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@
    - You can also run `python gui.py` directly if you manage your own environment.
 3. The Fusion2X GUI will launch. All logs are saved in `logs/`.
 
+### CLI usage
+
+You can also submit jobs directly from the command line:
+
+```bash
+python receiver.py --task upscaling --input_path input.png --output_path out_dir \
+    --input_format png --output_format png
+```
+
+The command prints a JSON result containing the output path and log location.
+
 
 ## To update Fusion2X
 

--- a/receiver.py
+++ b/receiver.py
@@ -101,24 +101,30 @@ def main():
     try:
         logger.info("Fusion2X receiver started.")
 
-        # Read job request as JSON from stdin
-        input_data = ""
-        if not sys.stdin.isatty():
-            input_data = sys.stdin.read()
-            logger.info("Received JSON from stdin.")
+        if len(sys.argv) > 1:
+            # CLI invocation with arguments
+            args = parse_cli_args()
+            json_request = build_json_from_args(args)
+            logger.info("Received job config from CLI args.")
         else:
-            logger.error("No input received. Exiting.")
-            print(json.dumps({"status": "error", "message": "No input provided.", "log_path": log_path}))
-            sys.exit(1)
+            # Read job request as JSON from stdin
+            input_data = ""
+            if not sys.stdin.isatty():
+                input_data = sys.stdin.read()
+                logger.info("Received JSON from stdin.")
+            else:
+                logger.error("No input received. Exiting.")
+                print(json.dumps({"status": "error", "message": "No input provided.", "log_path": log_path}))
+                sys.exit(1)
 
-        try:
-            json_request = json.loads(input_data)
-        except Exception as e:
-            logger.error(f"Failed to parse input JSON: {e}")
-            print(json.dumps({"status": "error", "message": "Failed to parse input JSON.", "log_path": log_path}))
-            sys.exit(1)
+            try:
+                json_request = json.loads(input_data)
+            except Exception as e:
+                logger.error(f"Failed to parse input JSON: {e}")
+                print(json.dumps({"status": "error", "message": "Failed to parse input JSON.", "log_path": log_path}))
+                sys.exit(1)
 
-        logger.info(f"Received job config: {json.dumps(json_request, indent=2)}")
+            logger.info(f"Received job config: {json.dumps(json_request, indent=2)}")
 
         # Add log_path to the request, if not already present
         if "log_path" not in json_request:

--- a/tests/test_receiver_cli.py
+++ b/tests/test_receiver_cli.py
@@ -1,0 +1,27 @@
+import sys
+import receiver
+
+
+def test_parse_cli_args_and_build_json(monkeypatch):
+    argv = ["receiver.py", "--task", "upscaling", "--input_path", "in.png",
+            "--output_path", "out", "--input_format", "png", "--output_format",
+            "png"]
+    monkeypatch.setattr(sys, "argv", argv)
+    args = receiver.parse_cli_args()
+    req = receiver.build_json_from_args(args)
+    assert req == {
+        "task": "upscaling",
+        "input_format": "png",
+        "output_format": "png",
+        "input_path": "in.png",
+        "output_path": "out",
+    }
+
+
+def test_build_json_omits_none(monkeypatch):
+    argv = ["receiver.py", "--task", "upscaling", "--input_path", "f.png",
+            "--input_format", "png", "--output_format", "png"]
+    monkeypatch.setattr(sys, "argv", argv)
+    args = receiver.parse_cli_args()
+    req = receiver.build_json_from_args(args)
+    assert "output_path" not in req


### PR DESCRIPTION
## Summary
- allow receiver to accept job data from CLI arguments when provided
- document basic CLI usage example
- test CLI argument parsing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842b28711f48333b6b596cbdabce8bd